### PR TITLE
Compiler warnings were supressed for clang/gcc

### DIFF
--- a/QGumboParser/QGumboParser.pro
+++ b/QGumboParser/QGumboParser.pro
@@ -47,8 +47,13 @@ HEADERS += \
     gumbo-parser/src/vector.h \
     HtmlTag.h
 
-contains(QMAKE_CC, gcc): {
+# NOTE: contains() is broken, so use equals() as workaround
+TEMP_CC = $$basename(QMAKE_CC)
+equals(TEMP_CC, "gcc"): {
     QMAKE_CFLAGS_WARN_ON += -Wno-unused-parameter -Wno-sign-compare -Wno-old-style-declaration
+}
+equals(TEMP_CC, "clang"): {
+    QMAKE_CFLAGS_WARN_ON += -Wno-unused-parameter -Wno-sign-compare
 }
 
 win32-msvc*: {


### PR DESCRIPTION
Looks like qmake function `contains` don't work correctly anymore (Qt 5.15.2, Qt 6.0.1).   
So i've replaced `contains` with `equals` and warnings eliminated again.  
Also clang support added.