### PR TITLE
Qt6 compilation issues fixed: QStringView used instead of QStringRef

### DIFF
--- a/QGumboParser/qgumbonode.cpp
+++ b/QGumboParser/qgumbonode.cpp
@@ -120,17 +120,32 @@ QGumboNodes QGumboNode::getElementsByClassName(const QString& name) const
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
             const QVector<QStringRef> parts =
                     value.splitRef(QChar(' '), QString::SkipEmptyParts, Qt::CaseInsensitive);
-#else
-            const QVector<QStringRef> parts =
-                    value.splitRef(QChar(' '), Qt::SkipEmptyParts, Qt::CaseInsensitive);
-#endif
-
             for (const QStringRef& part: parts) {
                 if (part.compare(name, Qt::CaseInsensitive) == 0) {
                     nodes.emplace_back(QGumboNode(node));
                     break;
                 }
             }
+#elif QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            const QVector<QStringRef> parts =
+                    value.splitRef(QChar(' '), Qt::SkipEmptyParts, Qt::CaseInsensitive);
+            for (const QStringRef& part: parts) {
+                if (part.compare(name, Qt::CaseInsensitive) == 0) {
+                    nodes.emplace_back(QGumboNode(node));
+                    break;
+                }
+            }
+#else
+            // Qt6 use QStringView instead of QStringRef
+            // More info about this on https://doc-snapshots.qt.io/qt6-dev/qtcore-changes-qt6.html#qstringref
+            const QList<QStringView> parts = QStringView { value }.split(u8' ');
+            for (const QStringView &part : parts) {
+                if (part.compare(name, Qt::CaseInsensitive) == 0) {
+                    nodes.emplace_back(QGumboNode(node));
+                    break;
+                }
+            }
+#endif
         }
         return false;
     };

--- a/QGumboParser/qgumbonode.h
+++ b/QGumboParser/qgumbonode.h
@@ -1,6 +1,7 @@
 #ifndef QGUMBONODE_H
 #define QGUMBONODE_H
 
+#include <QtCore/QtGlobal>
 #include <vector>
 #include <functional>
 #include "gumbo-parser/src/gumbo.h"
@@ -10,7 +11,9 @@ class QString;
 class QGumboNode;
 class QGumboAttribute;
 class QGumboDocument;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 class QStringList;
+#endif
 
 typedef std::vector<QGumboNode> 		QGumboNodes;
 typedef std::vector<QGumboAttribute> 	QGumboAttributes;


### PR DESCRIPTION
Qt6 replaced QStringRef with QStringView, so the old code will not compile anymore.   
So i've just added a `ifdef` branch for Qt6 with `QStringView` usage.  
Documentation: https://doc-snapshots.qt.io/qt6-dev/qtcore-changes-qt6.html#qstringref